### PR TITLE
install_carts tweaks

### DIFF
--- a/scripts/install_carts
+++ b/scripts/install_carts
@@ -14,14 +14,17 @@ PLAYLIST=$(curl -s https://raw.githubusercontent.com/alanxoc3/radico8/main/playl
 for cart in $(echo "$PLAYLIST" | awk -F : '{print $1}' | sort -u); do
     fullcartpath="$CARTS_PATH/$cart.p8.png"
     if [[ ! -f "$fullcartpath" ]] || [[ ! -s "$fullcartpath" ]]; then
-        url="http://www.lexaloffle.com/bbs/get_cart.php?cat=7&play_src=2&lid=$cart"
+        url="https://www.lexaloffle.com/bbs/get_cart.php?cat=7&play_src=2&lid=$cart"
         echo "CART DOWNLOAD: $url"
         wget "$url" -O "$fullcartpath"
+
+        echo "SLEEP zzz"  # be polite to the server!
+        sleep 5.00  # 3s is still too frequent -- many ERROR 429
     fi
 
     infocartpath="$CARTS_PATH/$cart.txt"
     if [[ ! -f "$infocartpath" ]] || [[ ! -s "$infocartpath" ]]; then
-        url="http://www.lexaloffle.com/bbs/cpost_lister3.php?lid=$cart"
+        url="https://www.lexaloffle.com/bbs/cpost_lister3.php?lid=$cart"
         echo "TEXT DOWNLOAD: $url"
         wget "$url" -O "$infocartpath"
     fi


### PR DESCRIPTION
very nice radio :)  I installed it locally today and made some adjustments to the install script:

- change http -> https (the server was responding to every request with 301 Moved Permanently, redirecting to the https equivalent)
- sleep after downloading each cart. this makes it much more likely for a single invocation to install all carts, and is more polite. I suppose it also makes incremental updates slower tho (after your cartridges dir is initialized) -- the server seems to let you download 5 or 10 carts as fast as you're able before it starts complaining. Maybe I should have made the sleep length a configurable commandline parameter

I notice that `./scripts/install_to_server` runs this script -- will that be a problem somehow? I assume it's fine but just wanted to ask